### PR TITLE
Track the players selected slot index

### DIFF
--- a/src/main/java/com/loohp/limbo/Events/PlayerSelectedSlotChangeEvent.java
+++ b/src/main/java/com/loohp/limbo/Events/PlayerSelectedSlotChangeEvent.java
@@ -1,0 +1,32 @@
+package com.loohp.limbo.Events;
+
+import com.loohp.limbo.Player.Player;
+
+public class PlayerSelectedSlotChangeEvent extends PlayerEvent implements Cancellable {
+
+    private boolean cancel = false;
+    private byte slot;
+
+    public PlayerSelectedSlotChangeEvent(Player player, byte slot) {
+        super(player);
+        this.slot = slot;
+    }
+
+    @Override
+    public void setCancelled(boolean cancelled) {
+        this.cancel = cancelled;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    public byte getSlot() {
+        return slot;
+    }
+
+    public void setSlot(byte slot) {
+        this.slot = slot;
+    }
+}

--- a/src/main/java/com/loohp/limbo/Player/Player.java
+++ b/src/main/java/com/loohp/limbo/Player/Player.java
@@ -18,6 +18,7 @@ import com.loohp.limbo.Server.Packets.PacketPlayOutChat;
 import com.loohp.limbo.Server.Packets.PacketPlayOutGameState;
 import com.loohp.limbo.Server.Packets.PacketPlayOutPositionAndLook;
 import com.loohp.limbo.Server.Packets.PacketPlayOutRespawn;
+import com.loohp.limbo.Server.Packets.PacketPlayOutHeldItemChange;
 import com.loohp.limbo.Utils.GameMode;
 
 import net.md_5.bungee.api.chat.BaseComponent;
@@ -32,6 +33,7 @@ public class Player extends LivingEntity implements CommandSender {
 	protected final String username;
 	protected GameMode gamemode;
 	protected DataWatcher watcher;
+	protected byte selectedSlot;
 	
 	@WatchableField(MetadataIndex = 14, WatchableObjectType = WatchableObjectType.FLOAT) 
 	protected float additionalHearts = 0.0F;
@@ -56,7 +58,23 @@ public class Player extends LivingEntity implements CommandSender {
 		this.watcher = new DataWatcher(this);
 		this.watcher.update();
 	}
-	
+
+	public byte getSelectedSlot() {
+		return selectedSlot;
+	}
+
+	public void setSelectedSlot(byte slot) {
+		if(slot == selectedSlot)
+			return;
+		try {
+			PacketPlayOutHeldItemChange state = new PacketPlayOutHeldItemChange(slot);
+			clientConnection.sendPacket(state);
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		this.selectedSlot = slot;
+	}
+
 	public GameMode getGamemode() {
 		return gamemode;
 	}

--- a/src/main/java/com/loohp/limbo/Player/Unsafe.java
+++ b/src/main/java/com/loohp/limbo/Player/Unsafe.java
@@ -22,5 +22,10 @@ public class Unsafe {
 	public void a(Player a, Location b) {
 		a.setLocation(b);
 	}
-	
+
+	@Deprecated
+	public void a(Player a, byte b) {
+		a.selectedSlot = b;
+	}
+
 }

--- a/src/main/java/com/loohp/limbo/Server/Packets/PacketPlayInHeldItemChange.java
+++ b/src/main/java/com/loohp/limbo/Server/Packets/PacketPlayInHeldItemChange.java
@@ -1,0 +1,21 @@
+package com.loohp.limbo.Server.Packets;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+
+public class PacketPlayInHeldItemChange extends PacketIn {
+
+    private final short slot;
+
+    public PacketPlayInHeldItemChange(short slot) {
+        this.slot = slot;
+    }
+
+    public PacketPlayInHeldItemChange(DataInputStream in) throws IOException {
+        this(in.readShort());
+    }
+
+    public short getSlot() {
+        return slot;
+    }
+}

--- a/src/main/java/com/loohp/limbo/Server/Packets/PacketPlayOutHeldItemChange.java
+++ b/src/main/java/com/loohp/limbo/Server/Packets/PacketPlayOutHeldItemChange.java
@@ -1,0 +1,29 @@
+package com.loohp.limbo.Server.Packets;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+public class PacketPlayOutHeldItemChange extends PacketOut {
+
+    private final byte slot;
+
+    public PacketPlayOutHeldItemChange(byte slot) {
+        this.slot = slot;
+    }
+
+    public byte getSlot() {
+        return slot;
+    }
+
+    @Override
+    public byte[] serializePacket() throws IOException {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+        DataOutputStream output = new DataOutputStream(buffer);
+        output.writeByte(Packet.getPlayOut().get(getClass()));
+        output.writeByte(slot);
+
+        return buffer.toByteArray();
+    }
+}

--- a/src/main/java/com/loohp/limbo/Unsafe.java
+++ b/src/main/java/com/loohp/limbo/Unsafe.java
@@ -28,12 +28,17 @@ public class Unsafe {
 			worldConstructor.setAccessible(false);
 		} catch (Exception e) {e.printStackTrace();}
 	}
-	
+
 	@Deprecated
 	public void setPlayerGameModeSilently(Player player, GameMode mode) {
 		playerUnsafe.a(player, mode);
 	}
-	
+
+	@Deprecated
+	public void setSelectedSlotSilently(Player player, byte slot) {
+		playerUnsafe.a(player, slot);
+	}
+
 	@Deprecated
 	public void setPlayerEntityId(Player player, int entityId) {
 		playerUnsafe.a(player, entityId);

--- a/src/main/resources/mapping.json
+++ b/src/main/resources/mapping.json
@@ -18,7 +18,8 @@
     "0x12": "PacketPlayInPosition",
     "0x14": "PacketPlayInRotation",
     "0x0B": "PacketPlayInPluginMessaging",
-    "0x06": "PacketPlayInTabComplete"
+    "0x06": "PacketPlayInTabComplete",
+    "0x25": "PacketPlayInHeldItemChange"
   },
   "PlayOut": {
     "PacketPlayOutLogin": "0x24",
@@ -41,7 +42,8 @@
     "PacketPlayOutEntityDestroy": "0x36",
     "PacketPlayOutEntityMetadata": "0x44",
     "PacketPlayOutSpawnEntity": "0x00",
-    "PacketPlayOutSpawnEntityLiving": "0x02"
+    "PacketPlayOutSpawnEntityLiving": "0x02",
+    "PacketPlayOutHeldItemChange": "0x3F"
   },
   "StatusIn": {
     "0x01": "PacketStatusInPing",


### PR DESCRIPTION
Track the players selected slot index with PacketPlayInHeldItemChange,

and allow changing of a players selected slot with
PacketPlayOutHeldItemChange.

Also introduces an event that can be used to change or cancel a player's
selected slot change.

I tried to follow the style and mannerisms of existing code, but what's
up with the Unsafe class? The class is okay, but why are the methods
named as such? Having all the methods named 'a' will be sure to cause
conflict once two methods take the same parameters.