### PR TITLE
Rework spawn world selection into it's own event.

### DIFF
--- a/src/main/java/com/loohp/limbo/Events/PlayerJoinEvent.java
+++ b/src/main/java/com/loohp/limbo/Events/PlayerJoinEvent.java
@@ -1,22 +1,10 @@
 package com.loohp.limbo.Events;
 
-import com.loohp.limbo.Location.Location;
 import com.loohp.limbo.Player.Player;
 
 public class PlayerJoinEvent extends PlayerEvent {
 
-	private Location spawnLocation;
-
-	public PlayerJoinEvent(Player player, Location spawnLoc) {
+	public PlayerJoinEvent(Player player) {
 		super(player);
-		spawnLocation = spawnLoc;
-	}
-
-	public Location getSpawnLocation() {
-		return spawnLocation;
-	}
-
-	public void setSpawnLocation(Location spawnLocation) {
-		this.spawnLocation = spawnLocation;
 	}
 }

--- a/src/main/java/com/loohp/limbo/Events/PlayerSpawnLocationEvent.java
+++ b/src/main/java/com/loohp/limbo/Events/PlayerSpawnLocationEvent.java
@@ -1,0 +1,21 @@
+package com.loohp.limbo.Events;
+
+import com.loohp.limbo.Location.Location;
+import com.loohp.limbo.Player.Player;
+
+public class PlayerSpawnLocationEvent extends PlayerEvent {
+    private Location location;
+
+    public PlayerSpawnLocationEvent(Player player, Location loc) {
+        super(player);
+        location = loc;
+    }
+
+    public Location getLocation() {
+        return location;
+    }
+
+    public void setLocation(Location location) {
+        this.location = location;
+    }
+}


### PR DESCRIPTION
The player is created a bit before we call the PlayerJoinEvent, and by
that time the player has already ticked and been sent some chunks for
their current world, which the PlayerJoinEvent wouldn't have had a
chance to modify.

This introduces a PlayerSpawnLocationEvent, which allows a spawn
location to be chosen for a player right as they are created, before
PlayerJoinEvent is called.

This solution is pretty bad. If you have any better way to implement
this correctly then certainly tell.