### PR TITLE
Feature: Added Velocity Modern Forwarding and BungeeGuard support!

### DIFF
--- a/src/main/java/com/loohp/limbo/file/ServerProperties.java
+++ b/src/main/java/com/loohp/limbo/file/ServerProperties.java
@@ -1,5 +1,6 @@
 package com.loohp.limbo.file;
 
+import com.google.common.collect.Lists;
 import com.loohp.limbo.Limbo;
 import com.loohp.limbo.location.Location;
 import com.loohp.limbo.utils.GameMode;
@@ -10,6 +11,7 @@ import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Properties;
@@ -35,7 +37,7 @@ public class ServerProperties {
 	private boolean bungeecord;
 	private boolean velocityModern;
 	private boolean bungeeGuard;
-	private String[] forwardingSecrets;
+	private List<String> forwardingSecrets;
 	private int viewDistance;
 	private double ticksPerSecond;
 	private boolean handshakeVerbose;
@@ -97,7 +99,7 @@ public class ServerProperties {
 				System.exit(1);
 				return;
 			}
-			this.forwardingSecrets = forwardingSecretsStr.split(";");
+			this.forwardingSecrets = Lists.newArrayList(forwardingSecretsStr.split(";"));
 			if (bungeecord) {
 				Limbo.getInstance().getConsole().sendMessage("BungeeCord is enabled but so is Velocity Modern Forwarding or BungeeGuard, We will automatically disable BungeeCord forwarding because of this");
 				bungeecord = false;
@@ -148,7 +150,7 @@ public class ServerProperties {
 		return bungeeGuard;
 	}
 
-	public String[] getForwardingSecrets() {
+	public List<String> getForwardingSecrets() {
 		return forwardingSecrets;
 	}
 

--- a/src/main/java/com/loohp/limbo/file/ServerProperties.java
+++ b/src/main/java/com/loohp/limbo/file/ServerProperties.java
@@ -1,25 +1,18 @@
 package com.loohp.limbo.file;
 
-import java.awt.image.BufferedImage;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
-import java.nio.charset.StandardCharsets;
-import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.Properties;
-
-import javax.imageio.ImageIO;
-
 import com.loohp.limbo.Limbo;
 import com.loohp.limbo.location.Location;
 import com.loohp.limbo.utils.GameMode;
 import com.loohp.limbo.utils.NamespacedKey;
 import com.loohp.limbo.world.World;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Properties;
 
 public class ServerProperties {
 	
@@ -40,6 +33,9 @@ public class ServerProperties {
 	private String versionString;
 	private int protocol;
 	private boolean bungeecord;
+	private boolean velocityModern;
+	private boolean bungeeGuard;
+	private String[] forwardingSecrets;
 	private int viewDistance;
 	private double ticksPerSecond;
 	private boolean handshakeVerbose;
@@ -91,6 +87,27 @@ public class ServerProperties {
 		motdJson = prop.getProperty("motd");
 		versionString = prop.getProperty("version");
 		bungeecord = Boolean.parseBoolean(prop.getProperty("bungeecord"));
+		velocityModern = Boolean.parseBoolean(prop.getProperty("velocity-modern"));
+		bungeeGuard = Boolean.parseBoolean(prop.getProperty("bungee-guard"));
+		if (velocityModern || bungeeGuard) {
+			String forwardingSecretsStr = prop.getProperty("forwarding-secrets");
+			if (forwardingSecretsStr == null || forwardingSecretsStr.equals("")) {
+				Limbo.getInstance().getConsole().sendMessage("Velocity Modern Forwarding or BungeeGuard is enabled but no forwarding-secret was found!");
+				Limbo.getInstance().getConsole().sendMessage("Server will exit!");
+				System.exit(1);
+				return;
+			}
+			this.forwardingSecrets = forwardingSecretsStr.split(";");
+			if (bungeecord) {
+				Limbo.getInstance().getConsole().sendMessage("BungeeCord is enabled but so is Velocity Modern Forwarding or BungeeGuard, We will automatically disable BungeeCord forwarding because of this");
+				bungeecord = false;
+			}
+			if (velocityModern && bungeeGuard) {
+				Limbo.getInstance().getConsole().sendMessage("Both Velocity Modern Forwarding and BungeeGuard are enabled! Because of this we always prefer Modern Forwarding, disabling BungeeGuard");
+				bungeeGuard = false;
+			}
+		}
+
 		viewDistance = Integer.parseInt(prop.getProperty("view-distance"));
 		ticksPerSecond = Double.parseDouble(prop.getProperty("ticks-per-second"));
 		handshakeVerbose = Boolean.parseBoolean(prop.getProperty("handshake-verbose"));
@@ -121,6 +138,18 @@ public class ServerProperties {
 
 	public boolean isBungeecord() {
 		return bungeecord;
+	}
+
+	public boolean isVelocityModern() {
+		return velocityModern;
+	}
+
+	public boolean isBungeeGuard() {
+		return bungeeGuard;
+	}
+
+	public String[] getForwardingSecrets() {
+		return forwardingSecrets;
 	}
 
 	public Optional<BufferedImage> getFavicon() {

--- a/src/main/java/com/loohp/limbo/server/packets/PacketLoginInPluginMessaging.java
+++ b/src/main/java/com/loohp/limbo/server/packets/PacketLoginInPluginMessaging.java
@@ -1,39 +1,39 @@
 package com.loohp.limbo.server.packets;
 
+import com.loohp.limbo.utils.DataTypeIO;
+
 import java.io.DataInputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-
-import com.loohp.limbo.utils.DataTypeIO;
-import com.loohp.limbo.utils.NamespacedKey;
 
 public class PacketLoginInPluginMessaging extends PacketIn {
 
 	private int messageId;
-	private NamespacedKey channel;
-	private byte[] data;
+	private boolean successful;
+	private byte[] data = null;
 
-	public PacketLoginInPluginMessaging(int messageId, NamespacedKey channel, byte[] data) {
+	public PacketLoginInPluginMessaging(int messageId, boolean successful, byte[] data) {
 		this.messageId = messageId;
-		this.channel = channel;
 		this.data = data;
 	}
 	
 	public PacketLoginInPluginMessaging(DataInputStream in, int packetLength, int packetId) throws IOException {
 		messageId = DataTypeIO.readVarInt(in);
-		String rawChannel = DataTypeIO.readString(in, StandardCharsets.UTF_8);
-		channel = new NamespacedKey(rawChannel);
-		int dataLength = packetLength - DataTypeIO.getVarIntLength(packetId) - DataTypeIO.getVarIntLength(messageId) - DataTypeIO.getStringLength(rawChannel, StandardCharsets.UTF_8);
-		data = new byte[dataLength];
-		in.read(data);
+		successful = in.readBoolean();
+		if (successful) {
+			int dataLength = packetLength - DataTypeIO.getVarIntLength(packetId) - DataTypeIO.getVarIntLength(messageId) - 1;
+			if (dataLength != 0) {
+				data = new byte[dataLength];
+				in.readFully(data);
+			}
+		}
 	}
 	
 	public int getMessageId() {
 		return messageId;
 	}
 
-	public NamespacedKey getChannel() {
-		return channel;
+	public boolean isSuccessful() {
+		return successful;
 	}
 
 	public byte[] getData() {

--- a/src/main/java/com/loohp/limbo/server/packets/PacketLoginOutPluginMessaging.java
+++ b/src/main/java/com/loohp/limbo/server/packets/PacketLoginOutPluginMessaging.java
@@ -1,18 +1,22 @@
 package com.loohp.limbo.server.packets;
 
+import com.loohp.limbo.utils.DataTypeIO;
+import com.loohp.limbo.utils.NamespacedKey;
+
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-
-import com.loohp.limbo.utils.DataTypeIO;
-import com.loohp.limbo.utils.NamespacedKey;
 
 public class PacketLoginOutPluginMessaging extends PacketOut {
 
 	private int messageId;
 	private NamespacedKey channel;
 	private byte[] data;
+
+	public PacketLoginOutPluginMessaging(int messageId, NamespacedKey channel) {
+		this(messageId, channel, null);
+	}
 
 	public PacketLoginOutPluginMessaging(int messageId, NamespacedKey channel, byte[] data) {
 		this.messageId = messageId;
@@ -40,7 +44,9 @@ public class PacketLoginOutPluginMessaging extends PacketOut {
 		output.writeByte(Packet.getLoginOut().get(getClass()));
 		DataTypeIO.writeVarInt(output, messageId);
 		DataTypeIO.writeString(output, channel.toString(), StandardCharsets.UTF_8);
-		output.write(data);
+		if (data != null) {
+			output.write(data);
+		}
 		
 		return buffer.toByteArray();
 	}

--- a/src/main/java/com/loohp/limbo/utils/DataTypeIO.java
+++ b/src/main/java/com/loohp/limbo/utils/DataTypeIO.java
@@ -23,6 +23,10 @@ public class DataTypeIO {
 		out.writeLong(uuid.getMostSignificantBits());
 		out.writeLong(uuid.getLeastSignificantBits());
 	}
+
+	public static UUID readUUID(DataInputStream in) throws IOException {
+		return new UUID(in.readLong(), in.readLong());
+	}
 	
 	public static void writeCompoundTag(DataOutputStream out, CompoundTag tag) throws IOException {
 		ByteArrayOutputStream buffer = new ByteArrayOutputStream();

--- a/src/main/java/com/loohp/limbo/utils/ForwardingUtils.java
+++ b/src/main/java/com/loohp/limbo/utils/ForwardingUtils.java
@@ -1,0 +1,127 @@
+package com.loohp.limbo.utils;
+
+import com.loohp.limbo.Limbo;
+
+import javax.crypto.Mac;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.UUID;
+
+public class ForwardingUtils {
+
+    public static final NamespacedKey VELOCITY_FORWARDING_CHANNEL = new NamespacedKey("velocity", "player_info");
+
+    public static boolean validateVelocityModernResponse(byte[] data) throws IOException {
+        ByteArrayInputStream byteIn = new ByteArrayInputStream(data);
+        DataInputStream input = new DataInputStream(byteIn);
+
+        byte[] signature = new byte[32];
+        input.readFully(signature);
+
+        boolean foundValid = false;
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            for (String secret : Limbo.getInstance().getServerProperties().getForwardingSecrets()) {
+                SecretKey key = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+                mac.init(key);
+                mac.update(data, 32, data.length - 32);
+                byte[] sig = mac.doFinal();
+                if (Arrays.equals(signature, sig)) {
+                    foundValid = true;
+                    break;
+                }
+            }
+        } catch (InvalidKeyException e) {
+            throw new RuntimeException("Unable to authenticate data", e);
+        } catch (NoSuchAlgorithmException e) {
+            // Should never happen
+            throw new AssertionError(e);
+        }
+
+        return foundValid;
+    }
+
+    public static VelocityModernForwardingData getVelocityDataFrom(byte[] data) throws IOException {
+        ByteArrayInputStream byteIn = new ByteArrayInputStream(data);
+        DataInputStream input = new DataInputStream(byteIn);
+
+        input.skipBytes(32);
+
+        int velocityVersion = DataTypeIO.readVarInt(input);
+        if (velocityVersion != 1) {
+            System.out.println("Unsupported Velocity version! Stopping Execution");
+            throw new AssertionError("Unknown Velocity Packet");
+        }
+        String address = DataTypeIO.readString(input, StandardCharsets.UTF_8);
+        UUID uuid = DataTypeIO.readUUID(input);
+        String username = DataTypeIO.readString(input, StandardCharsets.UTF_8);
+
+        //cycle properties
+        MojangAPIUtils.SkinResponse response = null;
+        int count = DataTypeIO.readVarInt(input);
+        for (int i = 0; i < count; ++i) {
+            String propertyName = DataTypeIO.readString(input, StandardCharsets.UTF_8);
+            String propertyValue = DataTypeIO.readString(input, StandardCharsets.UTF_8);
+            String propertySignature = "";
+            boolean signatureIncluded = input.readBoolean();
+            if (signatureIncluded) {
+                propertySignature = DataTypeIO.readString(input, StandardCharsets.UTF_8);
+            }
+            if (propertyName.equals("textures")) {
+                response = new MojangAPIUtils.SkinResponse(propertyValue, propertySignature);
+                break; // we don't use others properties for now
+            }
+        }
+
+        return new VelocityModernForwardingData(velocityVersion, address, uuid, username, response);
+    }
+
+    public static class VelocityModernForwardingData {
+
+        private final int version;
+        private final String ipAddress;
+        private final UUID uuid;
+        private final String username;
+        private final MojangAPIUtils.SkinResponse skinResponse;
+
+        public VelocityModernForwardingData(int version, String ipAddress, UUID uuid, String username, MojangAPIUtils.SkinResponse skinResponse) {
+            this.version = version;
+            this.ipAddress = ipAddress;
+            this.uuid = uuid;
+            this.username = username;
+            this.skinResponse = skinResponse;
+        }
+
+        public int getVersion()
+        {
+            return version;
+        }
+
+        public String getIpAddress()
+        {
+            return ipAddress;
+        }
+
+        public UUID getUuid()
+        {
+            return uuid;
+        }
+
+        public String getUsername()
+        {
+            return username;
+        }
+
+        public MojangAPIUtils.SkinResponse getSkinResponse()
+        {
+            return skinResponse;
+        }
+    }
+}

--- a/src/main/resources/mapping.json
+++ b/src/main/resources/mapping.json
@@ -9,7 +9,7 @@
   "LoginOut": {
     "PacketLoginOutLoginSuccess": "0x02",
     "PacketLoginOutDisconnect": "0x00",
-    "PacketLoginOutPluginMessaging": "0x04",
+    "PacketLoginOutPluginMessaging": "0x04"
   },
   "PlayIn": {
     "0x0F": "PacketPlayInKeepAlive",

--- a/src/main/resources/server.properties
+++ b/src/main/resources/server.properties
@@ -7,8 +7,20 @@ server-port=30000
 #Server ip, localhost for local access only
 server-ip=0.0.0.0
 
-#Whether this is server is behind a bungeecord proxy
+#Whether this server is behind a bungeecord proxy
+#Mutually exclusive with velocity-modern and bungee-guard
 bungeecord=false
+
+#Whether this server is behind a velocity proxy with modern player forwarding
+#Mutually exclusive with bungeecord and bungee-guard
+velocity-modern=false
+
+#Whether this server is behind a bungeecord proxy with BungeeGuard installed (velocity can do this too for <1.13)
+#Mutually exclusive with bungeecord and velocity-modern
+bungee-guard=false
+
+#For Velocity Modern Forwarding or BungeeGuard a list (separated by `;`) of valid secrets
+forwarding-secrets=
 
 #World Name and the Schematic file containing map
 level-name=world;spawn.schem


### PR DESCRIPTION
With this pull request, Limbo now supports Velocity Modern Forwarding natively. In `server.properties` set `velocity-modern` to true and add all your proxies' secrets to `forwarding-secrets` (as described in the default file in the repository).

To add a slightly increased safety measurement for proxies that older clients also connect to, you can also choose for the `bungee-guard` option which behaves exactly like the BungeeGuard plugin, tokens from BungeeGuard also go to `forwarding-secrets`.