### PR TITLE
Fixed ClientboundSetSubtitleTextPacket mapping

### DIFF
--- a/src/main/resources/mapping.json
+++ b/src/main/resources/mapping.json
@@ -46,9 +46,9 @@
     "PacketPlayOutHeldItemChange": "0x48",
     "PacketPlayOutPlayerListHeaderFooter": "0x5F",
     "PacketPlayOutResourcePackSend": "0x3C",
-	  "ClientboundSetTitlesAnimationPacket": "0x5B", 
-	  "ClientboundSetTitleTextPacket": "0x5A",
-	  "ClientboundSetTitleTextPacket": "0x58",
+    "ClientboundSetTitlesAnimationPacket": "0x5B", 
+    "ClientboundSetTitleTextPacket": "0x5A",
+    "ClientboundSetSubtitleTextPacket": "0x58",
     "ClientboundClearTitlesPacket": "0x10"
   },
   "StatusIn": {


### PR DESCRIPTION
ClientboundSetTitleTextPacket was mapped twice, once under 0x5A (The correct mapping) and under 0x58 (ClientboundSetSubtitleTextPacket 's mapping)