### PR TITLE
Forgot to remove System.out.println of the packet class

### DIFF
--- a/src/main/java/com/loohp/limbo/network/ClientConnection.java
+++ b/src/main/java/com/loohp/limbo/network/ClientConnection.java
@@ -202,7 +202,6 @@ public class ClientConnection extends Thread {
     }
 
     public synchronized void sendPacket(PacketOut packet) throws IOException {
-        System.out.println(packet.getClass());
         if (channel.writePacket(packet)) {
             setLastPacketTimestamp(System.currentTimeMillis());
         }


### PR DESCRIPTION
I had just downloaded the last version when I realized that the class of the packet was printed each time, so I propose this rather simple pullrequest to correct the problem.