### PR TITLE
Update files stored locally when they are different from .jar files

### DIFF
--- a/src/main/java/com/loohp/limbo/Limbo.java
+++ b/src/main/java/com/loohp/limbo/Limbo.java
@@ -206,13 +206,19 @@ public class Limbo {
 		
         String mappingName = "mapping.json";
         File mappingFile = new File(internalDataFolder, mappingName);
-        if (!mappingFile.exists()) {
-        	try (InputStream in = getClass().getClassLoader().getResourceAsStream(mappingName)) {
-                Files.copy(in, mappingFile.toPath());
-            } catch (IOException e) {
-            	e.printStackTrace();
-            }
-        }
+	InputStream mappingStreamIn = getClass().getClassLoader().getResourceAsStream(mappingName);
+	try {
+		if (!mappingFile.exists()) {
+			Files.copy(mappingStreamIn, mappingFile.toPath());
+		} else {
+			if (Files.newInputStream(mappingFile.toPath()) != mappingStreamIn) {
+				mappingFile.delete();
+				Files.copy(mappingStreamIn, mappingFile.toPath());
+			}
+		}
+	} catch (IOException e){
+		e.printStackTrace();
+	}
         
         console.sendMessage("Loading packet id mappings from mapping.json ...");
         

--- a/src/main/java/com/loohp/limbo/world/DimensionRegistry.java
+++ b/src/main/java/com/loohp/limbo/world/DimensionRegistry.java
@@ -46,18 +46,24 @@ public class DimensionRegistry {
 		this.defaultTag = new CompoundTag();
 		
 		String name = "dimension_registry.json";
-        File file = new File(Limbo.getInstance().getInternalDataFolder(), name);
-        if (!file.exists()) {
-        	try (InputStream in = Limbo.class.getClassLoader().getResourceAsStream(name)) {
-                Files.copy(in, file.toPath());
-            } catch (IOException e) {
-            	e.printStackTrace();
-            }
-        }
-        
-        this.reg = file;
-        
-        try (InputStreamReader reader = new InputStreamReader(Files.newInputStream(reg.toPath()), StandardCharsets.UTF_8)) {
+        File dimensionRegistryFile = new File(Limbo.getInstance().getInternalDataFolder(), name);
+		InputStream dimensionRegistryIn = Limbo.class.getClassLoader().getResourceAsStream(name);
+		try {
+			if (!dimensionRegistryFile.exists()) {
+				Files.copy(dimensionRegistryIn, dimensionRegistryFile.toPath());
+			} else {
+				if(Files.newInputStream(dimensionRegistryFile.toPath()) != dimensionRegistryIn) {
+					dimensionRegistryFile.delete();
+					Files.copy(dimensionRegistryIn, dimensionRegistryFile.toPath());
+				}
+			}
+		} catch (IOException e){
+			e.printStackTrace();
+		}
+
+        this.reg = dimensionRegistryFile;
+
+		try (InputStreamReader reader = new InputStreamReader(Files.newInputStream(reg.toPath()), StandardCharsets.UTF_8)) {
 			JSONObject json = (JSONObject) new JSONParser().parse(reader);
 			CompoundTag tag = CustomNBTUtils.getCompoundTagFromJson((JSONObject) json.get("value"));
 			defaultTag = tag;


### PR DESCRIPTION
When switching my Limbo server from the 1.18 version to the 1.19 version, an error appeared telling me that it could not find the `PacketPlayOutSpawnEntityLiving` class. After a few tries I realized that it was because the `mappings.json` file stored locally was not updated. To avoid this kind of error, I made this fix to solve the problem by simply updating the `mappings.json` file and `dimension_registry.json` if the locally stored ones are different from the ones contained in the .jar. 