### PR TITLE
Added the option to hide IP addresses in logs

### DIFF
--- a/src/main/java/com/loohp/limbo/file/ServerProperties.java
+++ b/src/main/java/com/loohp/limbo/file/ServerProperties.java
@@ -59,6 +59,7 @@ public class ServerProperties {
 	private GameMode defaultGamemode;
 	private Location worldSpawn;
 	private boolean reducedDebugInfo;
+	private boolean logPlayerIPAddresses;
 	private boolean allowFlight;
 	private boolean allowChat;
 	private Component motd;
@@ -123,6 +124,7 @@ public class ServerProperties {
 		float pitch = Float.parseFloat(locStr[5]);
 		worldSpawn = new Location(world, x, y, z, yaw, pitch);
 		reducedDebugInfo = Boolean.parseBoolean(prop.getProperty("reduced-debug-info"));
+		logPlayerIPAddresses = Boolean.parseBoolean(prop.getProperty("log-player-ip-addresses"));
 		allowFlight = Boolean.parseBoolean(prop.getProperty("allow-flight"));
 		allowChat = Boolean.parseBoolean(prop.getProperty("allow-chat"));
 		String motdJson = prop.getProperty("motd");
@@ -255,6 +257,10 @@ public class ServerProperties {
 
 	public boolean isReducedDebugInfo() {
 		return reducedDebugInfo;
+	}
+
+	public boolean isLogPlayerIPAddresses() {
+		return logPlayerIPAddresses;
 	}
 
 	public boolean isAllowFlight() {

--- a/src/main/java/com/loohp/limbo/network/ClientConnection.java
+++ b/src/main/java/com/loohp/limbo/network/ClientConnection.java
@@ -309,8 +309,9 @@ public class ClientConnection extends Thread {
                 state = ClientState.LEGACY;
                 channel.output.writeByte(255);
                 String str = inetAddress.getHostName() + ":" + clientSocket.getPort();
-                if(!properties.isLogPlayerIPAddresses())
+                if(!properties.isLogPlayerIPAddresses()) {
                     str = "<ip address withheld>" + ":" + clientSocket.getPort();
+                }
                 Limbo.getInstance().getConsole().sendMessage("[/" + str + "] <-> Legacy Status has pinged");
                 ServerProperties p = Limbo.getInstance().getServerProperties();
                 StatusPingEvent event = Limbo.getInstance().getEventsManager().callEvent(new StatusPingEvent(this, p.getVersionString(), p.getProtocol(), p.getMotd(), p.getMaxPlayers(), Limbo.getInstance().getPlayers().size(), p.getFavicon().orElse(null)));
@@ -343,8 +344,9 @@ public class ClientConnection extends Thread {
                                 ServerProperties properties = Limbo.getInstance().getServerProperties();
 
                                 String str = inetAddress.getHostName() + ":" + clientSocket.getPort();
-                                if(!properties.isLogPlayerIPAddresses())
+                                if(!properties.isLogPlayerIPAddresses()) {
                                     str = "<ip address withheld>" + ":" + clientSocket.getPort();
+                                }
                                 if (Limbo.getInstance().getServerProperties().handshakeVerboseEnabled()) {
                                     Limbo.getInstance().getConsole().sendMessage("[/" + str + "] <-> Handshake Status has pinged");
                                 }
@@ -504,9 +506,9 @@ public class ClientConnection extends Thread {
                 sendPacket(abilities);
 
                 String str = inetAddress.getHostName() + ":" + clientSocket.getPort() + "|" + player.getName() + "(" + player.getUniqueId() + ")";
-                if(!properties.isLogPlayerIPAddresses())
+                if(!properties.isLogPlayerIPAddresses()) {
                     str = "<ip address withheld>" + ":" + clientSocket.getPort() + "|" + player.getName() + "(" + player.getUniqueId() + ")";
-
+                }
                 Limbo.getInstance().getConsole().sendMessage("[/" + str + "] <-> Player had connected to the Limbo server!");
 
                 player.playerInteractManager.update();
@@ -675,8 +677,9 @@ public class ClientConnection extends Thread {
                 Limbo.getInstance().getEventsManager().callEvent(new PlayerQuitEvent(player));
 
                 str = inetAddress.getHostName() + ":" + clientSocket.getPort() + "|" + player.getName();
-                if(!properties.isLogPlayerIPAddresses())
+                if(!properties.isLogPlayerIPAddresses()) {
                     str = "<ip address withheld>" + ":" + clientSocket.getPort() + clientSocket.getPort() + "|" + player.getName();
+                }
 
                 Limbo.getInstance().getConsole().sendMessage("[/" + str + "] <-> Player had disconnected!");
 

--- a/src/main/java/com/loohp/limbo/network/ClientConnection.java
+++ b/src/main/java/com/loohp/limbo/network/ClientConnection.java
@@ -304,9 +304,13 @@ public class ClientConnection extends Thread {
 
             //legacy ping
             if (handShakeSize == 0xFE) {
+                ServerProperties properties = Limbo.getInstance().getServerProperties();
+
                 state = ClientState.LEGACY;
                 channel.output.writeByte(255);
                 String str = inetAddress.getHostName() + ":" + clientSocket.getPort();
+                if(!properties.isLogPlayerIPAddresses())
+                    str = "<ip address withheld>" + ":" + clientSocket.getPort();;
                 Limbo.getInstance().getConsole().sendMessage("[/" + str + "] <-> Legacy Status has pinged");
                 ServerProperties p = Limbo.getInstance().getServerProperties();
                 StatusPingEvent event = Limbo.getInstance().getEventsManager().callEvent(new StatusPingEvent(this, p.getVersionString(), p.getProtocol(), p.getMotd(), p.getMaxPlayers(), Limbo.getInstance().getPlayers().size(), p.getFavicon().orElse(null)));
@@ -336,7 +340,11 @@ public class ClientConnection extends Thread {
                         while (clientSocket.isConnected()) {
                             PacketIn packetIn = channel.readPacket();
                             if (packetIn instanceof PacketStatusInRequest) {
+                                ServerProperties properties = Limbo.getInstance().getServerProperties();
+
                                 String str = inetAddress.getHostName() + ":" + clientSocket.getPort();
+                                if(!properties.isLogPlayerIPAddresses())
+                                    str = "<ip address withheld>" + ":" + clientSocket.getPort();;
                                 if (Limbo.getInstance().getServerProperties().handshakeVerboseEnabled()) {
                                     Limbo.getInstance().getConsole().sendMessage("[/" + str + "] <-> Handshake Status has pinged");
                                 }
@@ -496,6 +504,9 @@ public class ClientConnection extends Thread {
                 sendPacket(abilities);
 
                 String str = inetAddress.getHostName() + ":" + clientSocket.getPort() + "|" + player.getName() + "(" + player.getUniqueId() + ")";
+                if(!properties.isLogPlayerIPAddresses())
+                    str = "<ip address withheld>" + ":" + clientSocket.getPort() + "|" + player.getName() + "(" + player.getUniqueId() + ")";
+
                 Limbo.getInstance().getConsole().sendMessage("[/" + str + "] <-> Player had connected to the Limbo server!");
 
                 player.playerInteractManager.update();
@@ -664,6 +675,9 @@ public class ClientConnection extends Thread {
                 Limbo.getInstance().getEventsManager().callEvent(new PlayerQuitEvent(player));
 
                 str = inetAddress.getHostName() + ":" + clientSocket.getPort() + "|" + player.getName();
+                if(!properties.isLogPlayerIPAddresses())
+                    str = "<ip address withheld>" + ":" + clientSocket.getPort() + clientSocket.getPort() + "|" + player.getName();
+
                 Limbo.getInstance().getConsole().sendMessage("[/" + str + "] <-> Player had disconnected!");
 
             }

--- a/src/main/java/com/loohp/limbo/network/ClientConnection.java
+++ b/src/main/java/com/loohp/limbo/network/ClientConnection.java
@@ -310,7 +310,7 @@ public class ClientConnection extends Thread {
                 channel.output.writeByte(255);
                 String str = inetAddress.getHostName() + ":" + clientSocket.getPort();
                 if(!properties.isLogPlayerIPAddresses())
-                    str = "<ip address withheld>" + ":" + clientSocket.getPort();;
+                    str = "<ip address withheld>" + ":" + clientSocket.getPort();
                 Limbo.getInstance().getConsole().sendMessage("[/" + str + "] <-> Legacy Status has pinged");
                 ServerProperties p = Limbo.getInstance().getServerProperties();
                 StatusPingEvent event = Limbo.getInstance().getEventsManager().callEvent(new StatusPingEvent(this, p.getVersionString(), p.getProtocol(), p.getMotd(), p.getMaxPlayers(), Limbo.getInstance().getPlayers().size(), p.getFavicon().orElse(null)));
@@ -344,7 +344,7 @@ public class ClientConnection extends Thread {
 
                                 String str = inetAddress.getHostName() + ":" + clientSocket.getPort();
                                 if(!properties.isLogPlayerIPAddresses())
-                                    str = "<ip address withheld>" + ":" + clientSocket.getPort();;
+                                    str = "<ip address withheld>" + ":" + clientSocket.getPort();
                                 if (Limbo.getInstance().getServerProperties().handshakeVerboseEnabled()) {
                                     Limbo.getInstance().getConsole().sendMessage("[/" + str + "] <-> Handshake Status has pinged");
                                 }

--- a/src/main/resources/server.properties
+++ b/src/main/resources/server.properties
@@ -44,6 +44,10 @@ world-spawn=world;20.5;17;22.5;-90;0
 #Reduce debug info
 reduced-debug-info=false
 
+#Whether the IP addresseses of players should be logged
+#If not enabled player IP addresses will be replaced by <ip address withheld> in logs
+log-player-ip-addresses=true
+
 #The view distance of the server
 view-distance=6
 


### PR DESCRIPTION
Due to GDPR and similar laws in some countries, server owners are better off without logging IP addresses in the case that a player requests a removal of his/her data. Most modern Minecraft server software has this config option already, but as Limbo was missing it I decided to add it!

Lmk if you need anything changed before merging.