### PR TITLE
A fix for Incorrect Payload Received in KeepAlive packet for player <XXX>

### DIFF
--- a/src/main/java/com/loohp/limbo/network/ClientConnection.java
+++ b/src/main/java/com/loohp/limbo/network/ClientConnection.java
@@ -616,7 +616,7 @@ public class ClientConnection extends Thread {
                             long lastPayload = getLastKeepAlivePayLoad();
                             PacketPlayInKeepAlive alive = (PacketPlayInKeepAlive) packetIn;
                             if (lastPayload == -1) {
-                                Limbo.getInstance().getConsole().sendMessage("Unsolicited KeepAlive packet for player " + player.getName() + " (payload " + String.valueOf(alive.getPayload()) + ")");
+                                Limbo.getInstance().getConsole().sendMessage("Unsolicited KeepAlive packet for player " + player.getName());
                             } else if (alive.getPayload() != lastPayload) {
                                 Limbo.getInstance().getConsole().sendMessage("Incorrect Payload received in KeepAlive packet for player " + player.getName());
                                 break;

--- a/src/main/java/com/loohp/limbo/network/ClientConnection.java
+++ b/src/main/java/com/loohp/limbo/network/ClientConnection.java
@@ -613,8 +613,11 @@ public class ClientConnection extends Thread {
                                 processMoveEvent.consume(event, to);
                             }
                         } else if (packetIn instanceof PacketPlayInKeepAlive) {
+                            long lastPayload = getLastKeepAlivePayLoad();
                             PacketPlayInKeepAlive alive = (PacketPlayInKeepAlive) packetIn;
-                            if (alive.getPayload() != getLastKeepAlivePayLoad()) {
+                            if (lastPayload == -1) {
+                                Limbo.getInstance().getConsole().sendMessage("Unsolicited KeepAlive packet for player " + player.getName() + " (payload " + String.valueOf(alive.getPayload()) + ")");
+                            } else if (alive.getPayload() != lastPayload) {
                                 Limbo.getInstance().getConsole().sendMessage("Incorrect Payload received in KeepAlive packet for player " + player.getName());
                                 break;
                             }


### PR DESCRIPTION
Fixes https://github.com/LOOHP/Limbo/issues/51 "Incorrect Payload Received in KeepAlive packet for player"

The problem is that in my setup (described in the issue linked above) the loohp-limbo server is receiving an unsolicited PacketInKeepAlive message prior to sending any out. This causes the payload validation check to fail, resulting in the connection then being closed.

This commit changes the PacketInKeepAlive handler to ignore (other than logging) unsolicited KeepAlive messages rather than act on them.

**Note: This is a duplicate of PR #52 , except it's now from a branch in my fork that has no other changes (I'm out of practice with github PRs).  Please look at that PR for @GrizzlT's comments about this change...**
