### PR TITLE
Teach Loohp-Limbo how to login clients connecting via floodgate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,12 @@ target/
 .classpath
 .project
 .settings/ 
+
+Loohp-Limbo.jar
+Loohp-Limbo-*.jar
+internal_data/
+logs/
+permission.yml
+plugins/
+server.properties
+

--- a/.gitignore
+++ b/.gitignore
@@ -12,12 +12,3 @@ target/
 .classpath
 .project
 .settings/ 
-
-Loohp-Limbo.jar
-Loohp-Limbo-*.jar
-internal_data/
-logs/
-permission.yml
-plugins/
-server.properties
-

--- a/src/main/java/com/loohp/limbo/network/ClientConnection.java
+++ b/src/main/java/com/loohp/limbo/network/ClientConnection.java
@@ -376,7 +376,7 @@ public class ClientConnection extends Thread {
                                         Limbo.getInstance().getConsole().sendMessage(String.valueOf(i) + ": " + data[i]);
                                     }
 
-                                    switch(state) {
+                                    switch (state) {
                                     default:
                                         Limbo.getInstance().getConsole().sendMessage(String.valueOf(i) + ": ignore data: State: " + String.valueOf(state));
                                         break;
@@ -385,7 +385,7 @@ public class ClientConnection extends Thread {
                                         state = 1;
                                         break;
                                     case 1:
-                                        if(data[i].startsWith("^Floodgate^")) {
+                                        if (data[i].startsWith("^Floodgate^")) {
                                             floodgate = data[i];
                                             state = 2;
                                             break;

--- a/src/main/java/com/loohp/limbo/network/ClientConnection.java
+++ b/src/main/java/com/loohp/limbo/network/ClientConnection.java
@@ -362,6 +362,7 @@ public class ClientConnection extends Thread {
                         state = ClientState.LOGIN;
 
                         if (isBungeecord || isBungeeGuard) {
+                            ServerProperties properties = Limbo.getInstance().getServerProperties();
                             try {
                                 String[] data = bungeeForwarding.split("\\x00");
                                 String host = "";
@@ -370,8 +371,11 @@ public class ClientConnection extends Thread {
                                 String bungee = "";
                                 String skinData = "";
                                 int state = 0;
-                                for(int i = 0; i < data.length; i++) {
-                                    Limbo.getInstance().getConsole().sendMessage(String.valueOf(i) + ": " + data[i]);
+                                for (int i = 0; i < data.length; i++) {
+                                    if (!properties.isReducedDebugInfo()) {
+                                        Limbo.getInstance().getConsole().sendMessage(String.valueOf(i) + ": " + data[i]);
+                                    }
+
                                     switch(state) {
                                     default:
                                         Limbo.getInstance().getConsole().sendMessage(String.valueOf(i) + ": ignore data: State: " + String.valueOf(state));
@@ -401,12 +405,17 @@ public class ClientConnection extends Thread {
                                         break;
                                     }
                                 }
+                                if (state != 6) {
+                                    throw new IllegalStateException("Illegal bungee state: " + String.valueOf(state));
+                                }
 
-                                Limbo.getInstance().getConsole().sendMessage("Host: " + host);
-                                Limbo.getInstance().getConsole().sendMessage("Floodgate: " + floodgate);
-                                Limbo.getInstance().getConsole().sendMessage("clientIp: " + clientIp);
-                                Limbo.getInstance().getConsole().sendMessage("bungee: " + bungee);
-                                Limbo.getInstance().getConsole().sendMessage("skinData: " + skinData);
+                                if (!properties.isReducedDebugInfo()) {
+                                    Limbo.getInstance().getConsole().sendMessage("Host: " + host);
+                                    Limbo.getInstance().getConsole().sendMessage("Floodgate: " + floodgate);
+                                    Limbo.getInstance().getConsole().sendMessage("clientIp: " + clientIp);
+                                    Limbo.getInstance().getConsole().sendMessage("bungee: " + bungee);
+                                    Limbo.getInstance().getConsole().sendMessage("skinData: " + skinData);
+                                }
 
                                 bungeeUUID = UUID.fromString(bungee.replaceFirst("([0-9a-fA-F]{8})([0-9a-fA-F]{4})([0-9a-fA-F]{4})([0-9a-fA-F]{4})([0-9a-fA-F]+)", "$1-$2-$3-$4-$5"));
                                 inetAddress = InetAddress.getByName(clientIp);
@@ -434,10 +443,12 @@ public class ClientConnection extends Thread {
                                     break;
                                 }
                             } catch (Exception e) {
-                                StringWriter sw = new StringWriter();
-                                PrintWriter pw = new PrintWriter(sw);
-                                e.printStackTrace(pw);
-                                Limbo.getInstance().getConsole().sendMessage(sw.toString());
+                                if (!properties.isReducedDebugInfo()) {
+                                    StringWriter sw = new StringWriter();
+                                    PrintWriter pw = new PrintWriter(sw);
+                                    e.printStackTrace(pw);
+                                    Limbo.getInstance().getConsole().sendMessage(sw.toString());
+                                }
                                 Limbo.getInstance().getConsole().sendMessage("If you wish to use bungeecord's IP forwarding, please enable that in your bungeecord config.yml as well!");
                                 disconnectDuringLogin(new BaseComponent[] {new TextComponent(ChatColor.RED + "Please connect from the proxy!")});
                             }


### PR DESCRIPTION
This PR fixes #54.

Note that in the following LOGIN traces, PII has been removed, but the traces are otherwise unaltered.  These traces are from the code in the PR, so you should be able to reproduce.  I am not sure if this matters, but in the case where the Floodgate cipher is **not** sent, the client and server are on my LAN, but in the case where it **is** sent, the client is on my LAN and the server in in the cloud.  Velocity, Geyser, Floodgate and Loop Limbo configurations are identical in both locations, and software versions are also identical.

Client is the same iPad in both cases, running Minecraft 1.19.30.

_LOGIN from client where the Floodgate cipher is not sent_:
```
[14:45:08 Info] Loaded world minecraft:world!
[14:45:08 Info] Limbo server listening on /0.0.0.0:30000
[14:46:02 Info] 0: H.H.H.H
[14:46:02 Info] 1: C.C.C.C
[14:46:02 Info] 2: 000000000000000000090XXXXXXXXXXXX
[14:46:02 Info] 3: [{"name":"textures","value":"","signature":""},{"name":"textures","value":"XXX","signature":"XXX"}]
[14:46:02 Info] Host: H.H.H.H
[14:46:02 Info] Floodgate: 
[14:46:02 Info] clientIp: C.C.C.C
[14:46:02 Info] bungee: 00000000000000000009XXXXXXXXXXXX
[14:46:02 Info] skinData: [{"name":"textures","value":"","signature":""},{"name":"textures","value":"XXX","signature":"XXX"}]
[14:46:03 Info] [/192.168.50.165:49769|*XXX(00000000-0000-0000-0009-XXX)] <-> Player had connected to the Limbo server!
```
Note that the `Floodgate:` line shows no content, and there are only 4 items in the `data` array.

*Login from client where the Floodgate cipher is sent*:
```
[21:37:08 Info] Limbo server listening on /0.0.0.0:30000
[21:37:15 Info] 0: H.H.H.H
[21:37:15 Info] 1: ^Floodgate^>XXXXXXXXXXXXXXXX+XXXXXXXXXXXXXXXXXXXXXXXX
[21:37:15 Info] 2: C.C.C.C
[21:37:15 Info] 3: 00000000000000000009XXXXXXXXXXXX
[21:37:15 Info] 4: [{"name":"textures","value":"XXX","signature":"XXX"}]
[21:37:15 Info] Host: H.H.H.H
[21:37:15 Info] Floodgate: ^Floodgate^>XXXXXXXXXXXXXXXX+XXXXXXXXXXXXXXXXXXXXXXXX
[21:37:15 Info] clientIp: C.C.C.C
[21:37:15 Info] bungee: 00000000000000000009XXXXXXXXXXXX
[21:37:15 Info] skinData: [{"name":"textures","value":"XXX","signature":"XXX"}]
[21:37:16 Info] [C.C.C.C:52168|*XXXX(00000000-0000-0000-0009-XXXXXXXXXXXX)] <-> Player had connected to the Limbo server!
```
Note that the `Floodgate:` line is not empty, and there are 5 items in the `data` array.

The old code always assumed `data[1]` contained the bungeecord provided UUID, but as we can see from the two traces, sometimes it's at `data[1]` and sometimes it's at `data[2]`