### PR TITLE
player allow/deny via addition of support for allowlist.json

### DIFF
--- a/src/main/java/com/loohp/limbo/Limbo.java
+++ b/src/main/java/com/loohp/limbo/Limbo.java
@@ -442,13 +442,11 @@ public class Limbo {
 			return true;
 		}
 
-		for (UUID allowedUuid : properties.getAllowlist()) {
-			if (requestedUuid.equals(allowedUuid)) {
-				if(!properties.isReducedDebugInfo()) {
-					Limbo.getInstance().getConsole().sendMessage(String.format("allowlist: %s allowed", requestedUuid.toString()));
-				}
-				return true;
+		if (properties.uuidIsAllowed(requestedUuid)) {
+			if(!properties.isReducedDebugInfo()) {
+				Limbo.getInstance().getConsole().sendMessage(String.format("allowlist: %s allowed", requestedUuid.toString()));
 			}
+			return true;
 		}
 
 		if(!properties.isReducedDebugInfo()) {

--- a/src/main/java/com/loohp/limbo/Limbo.java
+++ b/src/main/java/com/loohp/limbo/Limbo.java
@@ -432,6 +432,31 @@ public class Limbo {
 	public ServerProperties getServerProperties() {
 		return properties;
 	}
+
+	public void reloadAllowlist() {
+		properties.reloadAllowlist();
+	}
+
+	public boolean uuidIsAllowed(UUID requestedUuid) {
+		if (!properties.isEnforceAllowlist()) {
+			return true;
+		}
+
+		for (UUID allowedUuid : properties.getAllowlist()) {
+			if (requestedUuid.equals(allowedUuid)) {
+				if(!properties.isReducedDebugInfo()) {
+					Limbo.getInstance().getConsole().sendMessage(String.format("allowlist: %s allowed", requestedUuid.toString()));
+				}
+				return true;
+			}
+		}
+
+		if(!properties.isReducedDebugInfo()) {
+			Limbo.getInstance().getConsole().sendMessage(String.format("allowlist: %s not allowed", requestedUuid.toString()));
+		}
+
+		return false;
+	}
 	
 	public ServerConnection getServerConnection() {
 		return server;

--- a/src/main/java/com/loohp/limbo/commands/DefaultCommands.java
+++ b/src/main/java/com/loohp/limbo/commands/DefaultCommands.java
@@ -165,6 +165,20 @@ public class DefaultCommands implements CommandExecutor, TabCompletor {
 			}
 			return;
 		}
+		if (args[0].equalsIgnoreCase("allowlist")) {
+			if (sender.hasPermission("limboserver.allowlist")) {
+				if (args.length != 2) {
+					sender.sendMessage(ChatColor.RED + "Invalid usage!");
+				} else if (!args[1].equalsIgnoreCase("reload")) {
+					sender.sendMessage(ChatColor.RED + "Invalid usage!");
+				} else {
+					Limbo.getInstance().reloadAllowlist();
+				}
+			} else {
+				sender.sendMessage(ChatColor.RED + "You do not have permission to use that command!");
+			}
+			return;
+		}
 	}
 	
 	@Override

--- a/src/main/java/com/loohp/limbo/file/ServerProperties.java
+++ b/src/main/java/com/loohp/limbo/file/ServerProperties.java
@@ -31,6 +31,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
@@ -84,7 +85,7 @@ public class ServerProperties {
 	private double ticksPerSecond;
 	private boolean handshakeVerbose;
 	private boolean enforceAllowlist;
-	private ArrayList<UUID> allowlist;
+	private HashMap<UUID, Boolean> allowlist;
 	
 	private String resourcePackSHA1;
 	private String resourcePackLink;
@@ -208,7 +209,7 @@ public class ServerProperties {
 	public void reloadAllowlist() {
         Console console = Limbo.getInstance().getConsole();
 
-		allowlist = new ArrayList<UUID>();
+		allowlist = new HashMap<UUID, Boolean>();
         try {
             JSONParser parser = new JSONParser();
             Object obj = parser.parse(new FileReader("allowlist.json"));
@@ -241,7 +242,7 @@ public class ServerProperties {
 
 				String uuidStr = (String) o;
                 UUID allowedUuid = UUID.fromString(uuidStr);
-				allowlist.add(allowedUuid);
+				allowlist.put(allowedUuid, true);
             }
         } catch (IllegalArgumentException e) {
                 console.sendMessage(e.toString());
@@ -368,8 +369,11 @@ public class ServerProperties {
 		return enforceAllowlist;
 	}
 
-	public ArrayList<UUID> getAllowlist() {
-		return allowlist;
+	public boolean uuidIsAllowed(UUID requestedUuid)  {
+		if (allowlist.containsKey(requestedUuid)) {
+			return true;
+		}
+		return false;
 	}
 	
 	public String getResourcePackLink() {

--- a/src/main/java/com/loohp/limbo/network/ClientConnection.java
+++ b/src/main/java/com/loohp/limbo/network/ClientConnection.java
@@ -19,6 +19,7 @@
 
 package com.loohp.limbo.network;
 
+import com.loohp.limbo.Console;
 import com.loohp.limbo.Limbo;
 import com.loohp.limbo.events.player.PlayerJoinEvent;
 import com.loohp.limbo.events.player.PlayerSpawnEvent;
@@ -88,6 +89,7 @@ import com.loohp.limbo.utils.MojangAPIUtils.SkinResponse;
 import com.loohp.limbo.utils.NamespacedKey;
 import com.loohp.limbo.world.BlockPosition;
 import com.loohp.limbo.world.World;
+
 import net.kyori.adventure.text.Component;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.BaseComponent;
@@ -96,11 +98,14 @@ import net.md_5.bungee.api.chat.TranslatableComponent;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataInput;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.net.InetAddress;
@@ -108,6 +113,7 @@ import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
@@ -294,6 +300,84 @@ public class ClientConnection extends Thread {
         });
     }
 
+    public boolean uuidAllowed(UUID uuid, boolean verbose) {
+        Console console = Limbo.getInstance().getConsole();
+
+        try {
+            JSONParser parser = new JSONParser();
+            Object obj = parser.parse(new FileReader("allowlist.json"));
+
+            if (!(obj instanceof JSONArray)) {
+                if (verbose) {
+                    console.sendMessage("allowlist: expected [] got {}");
+                }
+                return false;
+            }
+
+            JSONArray array = (JSONArray) obj;
+
+            Iterator<?> iter = array.iterator();
+            while (iter.hasNext()) {
+                Object o = iter.next();
+                if (!(o instanceof JSONObject)) {
+                    if (verbose) {
+                        console.sendMessage("allowlist: array element is not an object");
+                    }
+                    continue;
+                }
+
+                JSONObject element = (JSONObject) o;
+                o = element.get("uuid");
+                if (o == null) {
+                    if (verbose) {
+                        console.sendMessage("allowlist: missing uuid attribute");
+                    }
+                    continue;
+                }
+                if (!(o instanceof String)) {
+                    if (verbose) {
+                        console.sendMessage("allowlist: uuid is not a string");
+                    }
+                    continue;
+                }
+                String uuidStr = (String) o;
+
+                UUID allowedUuid = UUID.fromString(uuidStr);
+                if (uuid.equals(allowedUuid)) {
+                    if(verbose) {
+                        console.sendMessage(String.format("allowlist: %s allowed", uuid.toString()));
+                    }
+                    return true;
+                }
+            }
+        } catch (IllegalArgumentException e) {
+            if (verbose) {
+                console.sendMessage(e.toString());
+            }
+            return false;
+        } catch (FileNotFoundException e) {
+            if (verbose) {
+                console.sendMessage(String.format("allowlist: no allowlist: %s allowed", uuid.toString()));
+            }
+            return true;
+        } catch (IOException e) {
+            if (verbose) {
+                console.sendMessage(String.format("allowlist: %s", e.toString()));
+            }
+            return false;
+        } catch (ParseException e) {
+            if (verbose) {
+                console.sendMessage(String.format(" allowlist: parse: %s", e.toString()));
+            }
+            return false;
+        }
+
+        if (verbose) {
+            console.sendMessage(String.format("allowlist: %s is not allowed", uuid.toString()));
+        }
+        return false;
+    }
+
     @SuppressWarnings("deprecation")
     @Override
     public void run() {
@@ -360,9 +444,9 @@ public class ClientConnection extends Thread {
                         break;
                     case LOGIN:
                         state = ClientState.LOGIN;
+                        ServerProperties properties = Limbo.getInstance().getServerProperties();
 
                         if (isBungeecord || isBungeeGuard) {
-                            ServerProperties properties = Limbo.getInstance().getServerProperties();
                             try {
                                 String[] data = bungeeForwarding.split("\\x00");
                                 String host = "";
@@ -468,6 +552,11 @@ public class ClientConnection extends Thread {
                                 }
 
                                 UUID uuid = isBungeecord || isBungeeGuard ? bungeeUUID : UUID.nameUUIDFromBytes(("OfflinePlayer:" + username).getBytes(StandardCharsets.UTF_8));
+
+                                if (!uuidAllowed(uuid, !properties.isReducedDebugInfo())) {
+                                    disconnectDuringLogin(TextComponent.fromLegacyText("You are not invited to this server"));
+                                    break;
+                                }
 
                                 PacketLoginOutLoginSuccess success = new PacketLoginOutLoginSuccess(uuid, username);
                                 sendPacket(success);

--- a/src/main/resources/server.properties
+++ b/src/main/resources/server.properties
@@ -80,3 +80,7 @@ required-resource-pack=false
 
 #JSON formatted text to show when prompting the player to install the resource pack (May be left blank)
 resource-pack-prompt={"text":"","extra":[{"text":"Install server resource pack!","color":"yellow"}]}
+
+#Whether to enforce the player allowlist.  If true, loads and enforces the allowlist from 'allowlist.json'
+#in the same format as vanilla minecraft servers
+enforce-allowlist=false


### PR DESCRIPTION
For my limbo server use case, I need to allow only certain users to be able to join.  I noticed the limbo server doesn't support this functionality, so I added it.  Not sure if this is useful for the community, but I'm sharing it back in case it is.

* It processes `allowlist.json` files in the same format as standard Minecraft servers.
* If no `allowlist.json` exists, it allows the player to connect.
* If it fails to parse the allowlist, it doesn't allow the player to connect.
* If the player's UUID shows up in the allowlist, it allows the player to connect, otherwise it doesn't allow them.
* If the `server.properties` `reduced-debug-info` flag is set to false, then it sends a message to the console each time it allows or denies a user.
