### PR TITLE
Add support for transfers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 	<groupId>com.loohp</groupId>
 	<artifactId>Limbo</artifactId>
 	<name>Limbo</name>
-	<version>0.7.15-ALPHA</version>
+	<version>0.7.16-ALPHA</version>
 	
 	<description>Standalone Limbo Minecraft Server.</description>
 	<url>https://github.com/LOOHP/Limbo</url>

--- a/src/main/java/com/loohp/limbo/commands/DefaultCommands.java
+++ b/src/main/java/com/loohp/limbo/commands/DefaultCommands.java
@@ -180,6 +180,77 @@ public class DefaultCommands implements CommandExecutor, TabCompletor {
 			}
 			return;
 		}
+
+        if (args[0].equalsIgnoreCase("transfer")) {
+            if (sender.hasPermission("limboserver.transfer")) {
+                if (args.length == 4) {
+                    Player player = Limbo.getInstance().getPlayer(args[1]);
+                    if (player != null) {
+                        String host = args[2];
+                        int port;
+                        try {
+                            port = Integer.parseInt(args[3]);
+                        } catch (NumberFormatException e) {
+                            sender.sendMessage(ChatColor.RED + "Invalid port number!");
+                            return;
+                        }
+                        player.transfer(host, port);
+                        sender.sendMessage(ChatColor.GOLD + "Transferred " + player.getName() + " to " + host + ":" + port);
+                    } else {
+                        sender.sendMessage(ChatColor.RED + "Player is not online!");
+                    }
+                } else {
+                    sender.sendMessage(ChatColor.RED + "Invalid usage! Use: /transfer <player> <host> <port>");
+                }
+            } else {
+                sender.sendMessage(ChatColor.RED + "You do not have permission to use that command!");
+            }
+            return;
+        }
+
+        if (args[0].equalsIgnoreCase("transferall")) {
+            if (sender.hasPermission("limboserver.transfer")) {
+                if (args.length >= 3 && args.length <= 5) {
+                    String host = args[1];
+                    int port;
+                    int batchDelay;
+                    int batchSize;
+                    try {
+                        port = Integer.parseInt(args[2]);
+                    } catch (NumberFormatException e) {
+                        sender.sendMessage(ChatColor.RED + "Invalid port!");
+                        return;
+                    }
+                    if (args.length == 4) {
+                        try {
+                            batchDelay = Integer.parseInt(args[3]);
+                        } catch (NumberFormatException e) {
+                            sender.sendMessage(ChatColor.RED + "Invalid batch delay ticks!");
+                            return;
+                        }
+                        batchSize = 1;
+                    } else if (args.length == 5) {
+                        try {
+                            batchDelay = Integer.parseInt(args[3]);
+                            batchSize = Integer.parseInt(args[4]);
+                        } catch (NumberFormatException e) {
+                            sender.sendMessage(ChatColor.RED + "Invalid batch delay ticks or size!");
+                            return;
+                        }
+                    } else {
+                        batchDelay = 1;
+                        batchSize = 10;
+                    }
+                    Limbo.getInstance().transferAll(host, port, batchDelay, batchSize);
+                    sender.sendMessage(ChatColor.GOLD + "Transferred all players to " + host + ":" + port);
+                } else {
+                    sender.sendMessage(ChatColor.RED + "Invalid usage! Use: /transferall <host> <port> [<batchDelayTicks> <batchSize>]");
+                }
+            } else {
+                sender.sendMessage(ChatColor.RED + "You do not have permission to use that command!");
+            }
+            return;
+        }
 	}
 	
 	@Override
@@ -202,6 +273,10 @@ public class DefaultCommands implements CommandExecutor, TabCompletor {
 			if (sender.hasPermission("limboserver.gamemode")) {
 				tab.add("gamemode");
 			}
+            if (sender.hasPermission("limboserver.transfer")) {
+                tab.add("transfer");
+                tab.add("transferall");
+            }
 			break;
 		case 1:
 			if (sender.hasPermission("limboserver.spawn")) {
@@ -229,6 +304,14 @@ public class DefaultCommands implements CommandExecutor, TabCompletor {
 					tab.add("gamemode");
 				}
 			}
+            if (sender.hasPermission("limboserver.transfer")) {
+                if ("transfer".startsWith(args[0].toLowerCase())) {
+                    tab.add("transfer");
+                }
+                if ("transferall".startsWith(args[0].toLowerCase())) {
+                    tab.add("transferall");
+                }
+            }
 			break;
 		case 2:
 			if (sender.hasPermission("limboserver.kick")) {
@@ -249,6 +332,15 @@ public class DefaultCommands implements CommandExecutor, TabCompletor {
 					}
 				}
 			}
+            if (sender.hasPermission("limboserver.transfer")) {
+                if (args[0].equalsIgnoreCase("transfer")) {
+                    for (Player player : Limbo.getInstance().getPlayers()) {
+                        if (player.getName().toLowerCase().startsWith(args[1].toLowerCase())) {
+                            tab.add(player.getName());
+                        }
+                    }
+                }
+            }
 			break;
 		case 3:
 			if (sender.hasPermission("limboserver.gamemode")) {

--- a/src/main/java/com/loohp/limbo/network/protocol/packets/ClientboundTransferPacket.java
+++ b/src/main/java/com/loohp/limbo/network/protocol/packets/ClientboundTransferPacket.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of Limbo.
+ *
+ * Copyright (C) 2022. LoohpJames <jamesloohp@gmail.com>
+ * Copyright (C) 2022. Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.loohp.limbo.network.protocol.packets;
+
+import com.loohp.limbo.registry.PacketRegistry;
+import com.loohp.limbo.utils.DataTypeIO;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class ClientboundTransferPacket extends PacketOut {
+
+    private final String host;
+    private final int port;
+
+    public ClientboundTransferPacket(String host, int port) {
+        this.host = host;
+        this.port = port;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    @Override
+    public byte[] serializePacket() throws IOException {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+        DataOutputStream output = new DataOutputStream(buffer);
+        output.writeByte(PacketRegistry.getPacketId(getClass()));
+        DataTypeIO.writeString(output, host, StandardCharsets.UTF_8);
+        DataTypeIO.writeVarInt(output, port);
+
+        return buffer.toByteArray();
+    }
+}

--- a/src/main/java/com/loohp/limbo/player/Player.java
+++ b/src/main/java/com/loohp/limbo/player/Player.java
@@ -45,6 +45,7 @@ import com.loohp.limbo.network.protocol.packets.ClientboundSetSubtitleTextPacket
 import com.loohp.limbo.network.protocol.packets.ClientboundSetTitleTextPacket;
 import com.loohp.limbo.network.protocol.packets.ClientboundSetTitlesAnimationPacket;
 import com.loohp.limbo.network.protocol.packets.ClientboundSystemChatPacket;
+import com.loohp.limbo.network.protocol.packets.ClientboundTransferPacket;
 import com.loohp.limbo.network.protocol.packets.PacketOut;
 import com.loohp.limbo.network.protocol.packets.PacketPlayOutCloseWindow;
 import com.loohp.limbo.network.protocol.packets.PacketPlayOutGameStateChange;
@@ -650,4 +651,13 @@ public class Player extends LivingEntity implements CommandSender, InventoryHold
 	public InventoryHolder getHolder() {
 		return this;
 	}
+
+    public void transfer(String host, int port) {
+        try {
+            ClientboundTransferPacket transferPacket = new ClientboundTransferPacket(host, port);
+            clientConnection.sendPacket(transferPacket);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
 }

--- a/src/main/java/com/loohp/limbo/registry/PacketRegistry.java
+++ b/src/main/java/com/loohp/limbo/registry/PacketRegistry.java
@@ -35,6 +35,7 @@ import com.loohp.limbo.network.protocol.packets.ClientboundSetSubtitleTextPacket
 import com.loohp.limbo.network.protocol.packets.ClientboundSetTitleTextPacket;
 import com.loohp.limbo.network.protocol.packets.ClientboundSetTitlesAnimationPacket;
 import com.loohp.limbo.network.protocol.packets.ClientboundSystemChatPacket;
+import com.loohp.limbo.network.protocol.packets.ClientboundTransferPacket;
 import com.loohp.limbo.network.protocol.packets.Packet;
 import com.loohp.limbo.network.protocol.packets.PacketHandshakingIn;
 import com.loohp.limbo.network.protocol.packets.PacketLoginInLoginStart;
@@ -220,6 +221,7 @@ public class PacketRegistry {
         registerClass(PacketPlayOutWindowData.class, "minecraft:container_set_data", NetworkPhase.PLAY, PacketBound.CLIENTBOUND);
         registerClass(ClientboundChunkBatchFinishedPacket.class, "minecraft:chunk_batch_finished", NetworkPhase.PLAY, PacketBound.CLIENTBOUND);
         registerClass(ClientboundChunkBatchStartPacket.class, "minecraft:chunk_batch_start", NetworkPhase.PLAY, PacketBound.CLIENTBOUND);
+        registerClass(ClientboundTransferPacket.class, "minecraft:transfer", NetworkPhase.PLAY, PacketBound.CLIENTBOUND);
     }
 
     private static void registerClass(Class<? extends Packet> packetClass, String key, NetworkPhase networkPhase, PacketBound packetBound) {

--- a/src/main/resources/permission.yml
+++ b/src/main/resources/permission.yml
@@ -4,6 +4,7 @@ groups:
     - limboserver.kick
     - limboserver.say
     - limboserver.gamemode
+    - limboserver.transfer
   default:
     - limboserver.spawn
     - limboserver.chat


### PR DESCRIPTION
This PR adds support for server transfers via a command. As a consequence, this API should also be accessible to plugins via `Player#transfer` and `Limbo#transferAll`.

Two commands are also added (with permission `limboserver.transfer`):
- `/transfer <player> <host> <port>`
  - `player`: the player to be transferred
  - `host`: the hostname of the destination server
  - `port`: the port number of the destination server
- `/transferall <host> <port> [<batchDelayTicks> <batchSize>]`
  - `host`: the hostname of the destination server
  - `port`: the port number of the destination server
  - `batchDelayTicks`: the number of ticks to wait between transferring each batch of players
  - `batchSize`: the number of players to transfer at one time