### PR TITLE
Fix: Send minimal DeclareCommands packet when no Limbo commands available

### DIFF
--- a/src/main/java/com/loohp/limbo/utils/DeclareCommands.java
+++ b/src/main/java/com/loohp/limbo/utils/DeclareCommands.java
@@ -34,12 +34,18 @@ public class DeclareCommands {
 	public static PacketPlayOutDeclareCommands getDeclareCommandsPacket(CommandSender sender) throws IOException {
 		List<String> commands = Limbo.getInstance().getPluginManager().getTabOptions(sender, new String[0]);
 		
-		if (commands.isEmpty()) {
-			return null;
-		}
-		
 		ByteArrayOutputStream buffer = new ByteArrayOutputStream();		
 		DataOutputStream output = new DataOutputStream(buffer);
+
+		if (commands.isEmpty()) {
+            DataTypeIO.writeVarInt(output, 1);
+
+            output.writeByte(0);
+            DataTypeIO.writeVarInt(output, 0);
+            DataTypeIO.writeVarInt(output, 0);
+
+            return new PacketPlayOutDeclareCommands(buffer.toByteArray());
+        }
 
 		DataTypeIO.writeVarInt(output, commands.size() * 2 + 1);
 		


### PR DESCRIPTION
Previously, when the command list was empty, the server returned null and did not send a DeclareCommands packet. This caused the client to lose the slash UI and tab completion entirely.  

Now, when there are no available commands, the server sends a minimal valid tree (only a root node with no children). This keeps the client UI functional while still reflecting the fact that no commands are available.