### PR TITLE
Fix typo causing login failure for 1.16-1.20 clients (Vialimbo)

### DIFF
--- a/src/main/java/com/loohp/limbo/registry/RegistryCustom.java
+++ b/src/main/java/com/loohp/limbo/registry/RegistryCustom.java
@@ -51,7 +51,7 @@ public class RegistryCustom {
     public static final RegistryCustom FROG_VARIANT = register("frog_variant");
     public static final RegistryCustom PAINTING_VARIANT = register("painting_variant");
     public static final RegistryCustom PIG_VARIANT = register("pig_variant");
-    public static final RegistryCustom TIMELINE = register("timelime");
+    public static final RegistryCustom TIMELINE = register("timeline");
     public static final RegistryCustom WOLF_SOUND_VARIANT = register("wolf_sound_variant");
     public static final RegistryCustom WOLF_VARIANT = register("wolf_variant");
     public static final RegistryCustom WORLDGEN_BIOME = register("worldgen/biome");


### PR DESCRIPTION
**Description:**
Fixed a critical typo where `timeline` was written as `timelime`.

**Reason:**
This typo causes the ViaBackwards protocol translation to fail. As a result, clients using versions 1.16 to 1.20 cannot log in to the server.

**Changes:**
- Corrected the spelling in RegistryCustom.java

I have tested this on my server and 1.16+ clients can join successfully now.